### PR TITLE
udpating for hapi 8

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -1,13 +1,13 @@
 var Payload = require('./payload');
 
 module.exports = function() {
-	var Handler = function(req, next) {
+	var Handler = function(req, reply) {
 		// transform boom payload to jsend
 		if(req && req.response && req.response.isBoom) {
 			Handler.transform(req.response.output.payload);
 		}
 
-		next();
+		reply.continue();
 	};
 
 	Handler.transform = function(data) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/selfcontained/hapi-boom-jsend",
   "devDependencies": {
     "lab": "^4.2.0",
-    "hapi": "^6.7.1",
+    "hapi": "^8.0.0",
     "boom": "^2.5.1",
     "jsend": "^0.1.2",
     "joi": "^4.6.2"

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -17,21 +17,28 @@ lab.experiment('hapi-boom-jsend transform', function() {
 		lab.test('should pass-through w/o a response on the request', function(done) {
 			var handler = Handler();
 
-			handler({}, function() {
+			handler({}, reply(function() {
 				Lab.assert.isTrue(true);
 				done();
-			});
+			}));
 		});
 
 		lab.test('should pass-through w/ a null request', function(done) {
 			var handler = Handler();
 
-			handler(null, function() {
+			handler(null, reply(function() {
 				Lab.assert.isTrue(true);
 				done();
-			});
+			}));
 		});
 
 	});
+
+	// return a reply-like interface
+	function reply(done) {
+		return {
+			continue: done
+		};
+	}
 
 });

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -6,18 +6,13 @@ var Lab = require('lab'),
 lab.experiment('Hapi plugin', function() {
 
 	lab.test('should register', function(done) {
-		var server = hapi.createServer();
+		var server = new hapi.Server();
 
-		server.pack.register(
-			{
-				plugin: HapiBoomJsend
-			},
-			function(err) {
-				Lab.assert.isUndefined(err);
+		server.register(HapiBoomJsend, function(err) {
+			Lab.assert.isUndefined(err);
 
-				done();
-			}
-		);
+			done();
+		});
 	});
 
 });

--- a/test/responses.test.js
+++ b/test/responses.test.js
@@ -35,7 +35,7 @@ lab.experiment('hapi-boom-jsend transform', function() {
 	lab.experiment('input validation', function() {
 
 		lab.test('without proper validation', function(done) {
-			var server = hapi.createServer();
+			var server = new hapi.Server().connection();
 
 			server.route({
 				method: 'POST',
@@ -81,7 +81,7 @@ lab.experiment('hapi-boom-jsend transform', function() {
 		});
 
 		lab.test('with proper validation', function(done) {
-			var server = hapi.createServer();
+			var server = new hapi.Server().connection();
 
 			server.route({
 				method: 'POST',

--- a/test/test-error.js
+++ b/test/test-error.js
@@ -1,9 +1,10 @@
 var Lab = require('lab'),
 	hapi = require('hapi'),
+	http = require('http'),
 	HapiBoomJsend = require('../index');
 
 module.exports = function testError(kaboom, expected, done) {
-	var server = hapi.createServer();
+	var server = new hapi.Server().connection();
 
 	server.route({
 		method: 'GET',
@@ -12,25 +13,20 @@ module.exports = function testError(kaboom, expected, done) {
 			reply(kaboom);
 		}
 	});
+	server.register(HapiBoomJsend, function(err) {
+		Lab.assert.isUndefined(err);
 
-	server.pack.register(
-		{
-			plugin: HapiBoomJsend
-		},
-		function(err) {
-			Lab.assert.isUndefined(err);
+		server.inject({
+			method: 'GET',
+			url: '/'
+		}, function(res) {
+			var payload = JSON.parse(res.payload);
 
-			server.inject({
-				method: 'GET',
-				url: '/'
-			}, function(res) {
-				var payload = JSON.parse(res.payload);
+			Lab.assert.deepEqual(payload, expected);
 
-				Lab.assert.deepEqual(payload, expected);
+			done();
+		});
 
-				done();
-			});
-		}
-	);
+	});
 
 };


### PR DESCRIPTION
- updates extension callback interface to use `reply.continue()`
- updated tests to account for new hapi api changes
